### PR TITLE
Make input filling work with React DOM 16.x

### DIFF
--- a/source/LoginTarget.js
+++ b/source/LoginTarget.js
@@ -3,6 +3,8 @@ import { getSharedObserver as getUnloadObserver } from "./UnloadObserver.js";
 
 export const FORCE_SUBMIT_DELAY = 7500;
 
+const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+
 /**
  * The LoginTarget class which represents a 'target' for logging in
  * with some credentials
@@ -141,13 +143,17 @@ export default class LoginTarget {
      */
     enterDetails(username, password) {
         this.usernameFields.slice(0, 1).forEach(field => {
-            field.value = username;
-            const changeEvent = new Event("change");
+            nativeInputValueSetter.call(field, username);
+            const inputEvent = new Event("input", { bubbles: true });
+            field.dispatchEvent(inputEvent);
+            const changeEvent = new Event("change", { bubbles: true });
             field.dispatchEvent(changeEvent);
         });
         this.passwordFields.slice(0, 1).forEach(field => {
-            field.value = password;
-            const changeEvent = new Event("change");
+            nativeInputValueSetter.call(field, password);
+            const inputEvent = new Event("input", { bubbles: true });
+            field.dispatchEvent(inputEvent);
+            const changeEvent = new Event("change", { bubbles: true });
             field.dispatchEvent(changeEvent);
         });
         return Promise.resolve();


### PR DESCRIPTION
Fixes #14 

The tricks:
- make sure the events bubble (I think react sometimes just listens higher up to reduce the number of listeners)
- fire first `input`, and then a `changed` event (this is what happens when using the keyboard to e.g. paste in a password)
- use the native `value`-setter (seems like React overrides this with something and for some reason that doesn't work 😕)